### PR TITLE
working GKE deploy

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -19,3 +19,41 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.3.0"
+  constraints = "~> 2.3.0"
+  hashes = [
+    "h1:mLNIobQGKfv/9kCqe7+41y2K8bC/Kjet4Fzc+ImcZeM=",
+    "zh:0c63c0aa9f13ec057971c9ddd0965e062b064c0b2ce9a3d13df41239b8f5af89",
+    "zh:14b4146e56b1c1e5492ce597d03fb993a71039dd701e3886667f7ad3d60afd34",
+    "zh:3882a3a091aeac1d42a01c7654c727a46870185d363454579e707c672a42f430",
+    "zh:3ccb84b23348e2b64ffe273170f686e6927e974060e37b52459ab2395bd59523",
+    "zh:4fb709aeb63dd6dee1e851459ac87c399ddb831ebfe9e28e4c9827c65bb55b67",
+    "zh:6739a4da9510f552b93fa77859f04c20af3a7a40a7f0b0073eb723af36b8156b",
+    "zh:7432b070124a161fe6a32dc6b76fd45100d079fdee917318460a82b80cda5518",
+    "zh:9aa51dc2a649fcaac133dad5c1e148c2e0f675fdf18b1d3b1da53549d8fa3b36",
+    "zh:a9a2abf1fbec56019473c8696d285703218ea0e8f2dc01879e7a391ea8785d57",
+    "zh:b3c25b085b7a7fbc05000303d82c54531987525575ff337e4be6fc152f4200d4",
+    "zh:fa8cb34df7786bbeffcee664eab72aeb15c4f8fba2d9c0b05faca6b3e819cf33",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.5.1"
+  constraints = "~> 2.5.0"
+  hashes = [
+    "h1:N++QrDDOE8L/FSYxFQSEicuwsUkh5V+OHFOJ4zRzLMc=",
+    "zh:05f42363a1bdf1858bfdb56dc55509a066a640d05ef62e0fddcf7cc4d97a0dfa",
+    "zh:2b974bebbc7823f759159fcf1efe0717930b7756f643ff1551e2d633a6651d10",
+    "zh:329817c534ae807ae88030f78e5c1ad1f124e9d5d7ae2830229a6d18ba7dd22e",
+    "zh:3c41ea252ded2788d7c47d613e9c1a6543d61e67905f9b1ebc8be23df556e844",
+    "zh:3fdff88596baf4f76dc64e016a5f7ba455b8b0b46b45e124e03074746f6a4d1b",
+    "zh:480819de824ab56074c4fcb9ebc5d7c7d44dda5fe6e9a3bc0b858b795f74ad41",
+    "zh:498fa4b9a5e73afe7560fe4540553a4e1e6a5691acc9384f0ebee32af0afe698",
+    "zh:6dfb17f21cc3dfd5096a1cf0d01603527213b127dade411f79c524d2bddc78b9",
+    "zh:b5132f132af0b0927d9cad126909d375aad2c11abed896a345529f1a2680eda8",
+    "zh:c0fc51da9dff350d29d3887660e8d390b2402ee415c190e17dbcf271d2234c16",
+    "zh:dfb1c8dd3409c7b09e2ffeeeadfa41cad076cc06b0d95a303ee096c01e9e68cf",
+  ]
+}

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,0 +1,24 @@
+/*
+ * GKE
+ */
+resource "google_container_cluster" "primary" {
+  name                  = local.cluster
+  location              = local.region
+  project               = local.project
+  network               = data.google_compute_network.vpc.self_link
+  subnetwork            = google_compute_subnetwork.cluster_subnetwork.name
+  enable_shielded_nodes = true
+  initial_node_count    = 1
+  // min_master_version    = var.kubernetes_version
+
+  # Needed for destroying the cluster for iterative dev
+  deletion_protection = false
+
+  # The CIDR blocks listed here have access to the GKE API.
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block   = data.google_compute_subnetwork.vpc_default.ip_cidr_range
+      display_name = "vpc_allowed"
+    }
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,22 @@
-//data "google_compute_zones" "available" {
-//  project = local.project
-//  region  = local.region
-//}
+/*
+ * Data
+ */
+# Fetch a new token with a 1 hour expiration.
+data "google_client_config" "this" {}
+
+# Used to initialize kubernetes providers
+data "google_container_cluster" "this" {
+  name       = local.cluster
+  location   = local.region
+  depends_on = [google_container_cluster.primary]
+}
+
+data "google_compute_zones" "available" {}
+
+data "google_compute_network" "vpc" {
+  name = local.vpcname
+}
+
+data "google_compute_subnetwork" "vpc_default" {
+  name = "${local.vpcname}-subnet"
+}

--- a/fw.tf
+++ b/fw.tf
@@ -1,3 +1,6 @@
+/*
+ * Google Firewall
+ */
 resource "google_compute_firewall" "access" {
   name    = "${local.vpcname}-default"
   network = google_compute_network.vpc.name

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,15 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.9"
+      version = "~> 5.9.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.5.0"
     }
   }
 }
@@ -16,13 +24,31 @@ locals {
   project = "rainbowq"
   region  = "us-west2"
   vpcname = "qio-dev"
-  //cluster = "qio-dev-gke-01"
-  //context = "dev"
-  //srvacct = "rainbowqio@rainbowq.iam.gserviceaccount.com"
+  cluster = "qio-dev-gke-01"
+  context = "dev"
+  srvacct = "rainbowqio@rainbowq.iam.gserviceaccount.com"
 }
 
 // Provider
 provider "google" {
   project = local.project
   region  = local.region
+}
+
+provider "kubernetes" {
+  host  = "https://${data.google_container_cluster.this.endpoint}"
+  token = data.google_client_config.this.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.this.master_auth.0.cluster_ca_certificate,
+  )
+}
+
+provider "helm" {
+  kubernetes {
+    host  = "https://${data.google_container_cluster.this.endpoint}"
+    token = data.google_client_config.this.access_token
+    cluster_ca_certificate = base64decode(
+      data.google_container_cluster.this.master_auth.0.cluster_ca_certificate,
+    )
+  }
 }

--- a/net.tf
+++ b/net.tf
@@ -1,0 +1,34 @@
+/*
+ * Networking
+ */
+resource "google_compute_subnetwork" "cluster_subnetwork" {
+  name          = "${local.vpcname}-${local.cluster}-subnet"
+  ip_cidr_range = var.cluster_subnet_cidr
+  network       = data.google_compute_network.vpc.self_link
+}
+
+resource "google_compute_router" "nat_router" {
+  name    = "${local.vpcname}-${local.cluster}-router"
+  network = data.google_compute_network.vpc.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_address" "nat_address" {
+  count = var.num_nat_instances
+  name  = "nat-${local.vpcname}-${local.cluster}-${count.index}"
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "${local.vpcname}-${local.cluster}-nat"
+  router                             = google_compute_router.nat_router.name
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = google_compute_address.nat_address.*.self_link
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.cluster_subnetwork.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+  depends_on = [google_container_cluster.primary]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+//variable "environment" { description = "Environment (free form, used for naming)" }
+//variable "kubernetes_version" { description = "GKE version" }
+//variable "endpoint_toggle" {
+//  description = "Toggle the availability of a public endpoint for the GKE API: 'false' means both public and private, 'true' means only private."
+//  default     = "false"
+//}
 variable "primary_cidr" {
   description = "Primary CIDR for the VPC"
   type        = string
@@ -8,4 +14,19 @@ variable "access_ssh_port" {
   description = "Access Port for SSH"
   type        = number
   default     = 22
+}
+
+variable "num_nat_instances" {
+  description = "Number of NAT instances to create, each having their own IP address"
+  default     = 1
+}
+
+variable "master_cidr_block" {
+  description = "Private CIDR for the control plane"
+  default     = "172.16.32.0/28"
+}
+
+variable "cluster_subnet_cidr" {
+  description = "GKE Subnet"
+  default     = "10.32.0.0/16"
 }


### PR DESCRIPTION
Here we have a new cluster being built in GKE.

```
<<< 17:38.22 Mon Dec/11/23|~/dev/github/maroda/craq.dev
<<< matt@earthsea|4144 exit:1 git:main vim:command
>>> tf apply
data.google_compute_zones.available: Reading...
data.google_compute_network.vpc: Reading...
data.google_client_config.this: Reading...
data.google_compute_subnetwork.vpc_default: Reading...
google_compute_network.vpc: Refreshing state... [id=projects/rainbowq/global/networks/qio-dev]
google_compute_address.nat_address[0]: Refreshing state... [id=projects/rainbowq/regions/us-west2/addresses/nat-qio-dev-qio-dev-gke-01-0]
data.google_client_config.this: Read complete after 0s [id=projects/"rainbowq"/regions/"us-west2"/zones/<null>]
data.google_compute_subnetwork.vpc_default: Read complete after 0s [id=projects/rainbowq/regions/us-west2/subnetworks/qio-dev-subnet]
data.google_compute_network.vpc: Read complete after 0s [id=projects/rainbowq/global/networks/qio-dev]
google_compute_subnetwork.cluster_subnetwork: Refreshing state... [id=projects/rainbowq/regions/us-west2/subnetworks/qio-dev-qio-dev-gke-01-subnet]
google_compute_router.nat_router: Refreshing state... [id=projects/rainbowq/regions/us-west2/routers/qio-dev-qio-dev-gke-01-router]
data.google_compute_zones.available: Read complete after 0s [id=projects/rainbowq/regions/us-west2]
google_compute_subnetwork.vpc_default: Refreshing state... [id=projects/rainbowq/regions/us-west2/subnetworks/qio-dev-subnet]
google_compute_firewall.access: Refreshing state... [id=projects/rainbowq/global/firewalls/qio-dev-default]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.google_container_cluster.this will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "google_container_cluster" "this" {
      + addons_config                     = (known after apply)
      + allow_net_admin                   = (known after apply)
      + authenticator_groups_config       = (known after apply)
      + binary_authorization              = (known after apply)
      + cluster_autoscaling               = (known after apply)
      + cluster_ipv4_cidr                 = (known after apply)
      + confidential_nodes                = (known after apply)
      + cost_management_config            = (known after apply)
      + database_encryption               = (known after apply)
      + datapath_provider                 = (known after apply)
      + default_max_pods_per_node         = (known after apply)
      + default_snat_status               = (known after apply)
      + deletion_protection               = (known after apply)
      + description                       = (known after apply)
      + dns_config                        = (known after apply)
      + enable_autopilot                  = (known after apply)
      + enable_intranode_visibility       = (known after apply)
      + enable_k8s_beta_apis              = (known after apply)
      + enable_kubernetes_alpha           = (known after apply)
      + enable_l4_ilb_subsetting          = (known after apply)
      + enable_legacy_abac                = (known after apply)
      + enable_shielded_nodes             = (known after apply)
      + enable_tpu                        = (known after apply)
      + endpoint                          = (known after apply)
      + fleet                             = (known after apply)
      + gateway_api_config                = (known after apply)
      + id                                = (known after apply)
      + identity_service_config           = (known after apply)
      + initial_node_count                = (known after apply)
      + ip_allocation_policy              = (known after apply)
      + label_fingerprint                 = (known after apply)
      + location                          = "us-west2"
      + logging_config                    = (known after apply)
      + logging_service                   = (known after apply)
      + maintenance_policy                = (known after apply)
      + master_auth                       = (known after apply)
      + master_authorized_networks_config = (known after apply)
      + master_version                    = (known after apply)
      + mesh_certificates                 = (known after apply)
      + min_master_version                = (known after apply)
      + monitoring_config                 = (known after apply)
      + monitoring_service                = (known after apply)
      + name                              = "qio-dev-gke-01"
      + network                           = (known after apply)
      + network_policy                    = (known after apply)
      + networking_mode                   = (known after apply)
      + node_config                       = (known after apply)
      + node_locations                    = (known after apply)
      + node_pool                         = (known after apply)
      + node_pool_auto_config             = (known after apply)
      + node_pool_defaults                = (known after apply)
      + node_version                      = (known after apply)
      + notification_config               = (known after apply)
      + operation                         = (known after apply)
      + private_cluster_config            = (known after apply)
      + private_ipv6_google_access        = (known after apply)
      + release_channel                   = (known after apply)
      + remove_default_node_pool          = (known after apply)
      + resource_labels                   = (known after apply)
      + resource_usage_export_config      = (known after apply)
      + security_posture_config           = (known after apply)
      + self_link                         = (known after apply)
      + service_external_ips_config       = (known after apply)
      + services_ipv4_cidr                = (known after apply)
      + subnetwork                        = (known after apply)
      + tpu_ipv4_cidr_block               = (known after apply)
      + vertical_pod_autoscaling          = (known after apply)
      + workload_identity_config          = (known after apply)
    }

  # google_compute_router_nat.nat will be created
  + resource "google_compute_router_nat" "nat" {
      + enable_dynamic_port_allocation      = (known after apply)
      + enable_endpoint_independent_mapping = (known after apply)
      + icmp_idle_timeout_sec               = 30
      + id                                  = (known after apply)
      + name                                = "qio-dev-qio-dev-gke-01-nat"
      + nat_ip_allocate_option              = "MANUAL_ONLY"
      + nat_ips                             = [
          + "https://www.googleapis.com/compute/v1/projects/rainbowq/regions/us-west2/addresses/nat-qio-dev-qio-dev-gke-01-0",
        ]
      + project                             = "rainbowq"
      + region                              = (known after apply)
      + router                              = "qio-dev-qio-dev-gke-01-router"
      + source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
      + tcp_established_idle_timeout_sec    = 1200
      + tcp_time_wait_timeout_sec           = 120
      + tcp_transitory_idle_timeout_sec     = 30
      + udp_idle_timeout_sec                = 30

      + subnetwork {
          + name                     = "qio-dev-qio-dev-gke-01-subnet"
          + secondary_ip_range_names = []
          + source_ip_ranges_to_nat  = [
              + "ALL_IP_RANGES",
            ]
        }
    }

  # google_container_cluster.primary will be created
  + resource "google_container_cluster" "primary" {
      + cluster_ipv4_cidr           = (known after apply)
      + datapath_provider           = (known after apply)
      + default_max_pods_per_node   = (known after apply)
      + deletion_protection         = false
      + enable_intranode_visibility = (known after apply)
      + enable_kubernetes_alpha     = false
      + enable_l4_ilb_subsetting    = false
      + enable_legacy_abac          = false
      + enable_shielded_nodes       = true
      + endpoint                    = (known after apply)
      + id                          = (known after apply)
      + initial_node_count          = 1
      + label_fingerprint           = (known after apply)
      + location                    = "us-west2"
      + logging_service             = (known after apply)
      + master_version              = (known after apply)
      + monitoring_service          = (known after apply)
      + name                        = "qio-dev-gke-01"
      + network                     = "https://www.googleapis.com/compute/v1/projects/rainbowq/global/networks/qio-dev"
      + networking_mode             = (known after apply)
      + node_locations              = (known after apply)
      + node_version                = (known after apply)
      + operation                   = (known after apply)
      + private_ipv6_google_access  = (known after apply)
      + project                     = "rainbowq"
      + self_link                   = (known after apply)
      + services_ipv4_cidr          = (known after apply)
      + subnetwork                  = "qio-dev-qio-dev-gke-01-subnet"
      + tpu_ipv4_cidr_block         = (known after apply)

      + master_authorized_networks_config {
          + gcp_public_cidrs_access_enabled = (known after apply)

          + cidr_blocks {
              + cidr_block   = "10.0.0.0/16"
              + display_name = "vpc_allowed"
            }
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes
```