### PR TITLE
working full GKE deploy from nothing

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -5,7 +5,7 @@ resource "google_container_cluster" "primary" {
   name                  = local.cluster
   location              = local.region
   project               = local.project
-  network               = data.google_compute_network.vpc.self_link
+  network               = google_compute_network.vpc.self_link
   subnetwork            = google_compute_subnetwork.cluster_subnetwork.name
   enable_shielded_nodes = true
   initial_node_count    = 1
@@ -17,7 +17,7 @@ resource "google_container_cluster" "primary" {
   # The CIDR blocks listed here have access to the GKE API.
   master_authorized_networks_config {
     cidr_blocks {
-      cidr_block   = data.google_compute_subnetwork.vpc_default.ip_cidr_range
+      cidr_block   = google_compute_subnetwork.vpc_default.ip_cidr_range
       display_name = "vpc_allowed"
     }
   }

--- a/data.tf
+++ b/data.tf
@@ -13,10 +13,10 @@ data "google_container_cluster" "this" {
 
 data "google_compute_zones" "available" {}
 
-data "google_compute_network" "vpc" {
-  name = local.vpcname
-}
+//data "google_compute_network" "vpc" {
+//  name = local.vpcname
+//}
 
-data "google_compute_subnetwork" "vpc_default" {
-  name = "${local.vpcname}-subnet"
-}
+//data "google_compute_subnetwork" "vpc_default" {
+//  name = "${local.vpcname}-subnet"
+//}

--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,8 @@ terraform {
 locals {
   project = "rainbowq"
   region  = "us-west2"
-  vpcname = "qio-dev"
-  cluster = "qio-dev-gke-01"
-  context = "dev"
+  vpcname = "rainbownet"
+  cluster = "qio-dev"
   srvacct = "rainbowqio@rainbowq.iam.gserviceaccount.com"
 }
 

--- a/net.tf
+++ b/net.tf
@@ -4,12 +4,12 @@
 resource "google_compute_subnetwork" "cluster_subnetwork" {
   name          = "${local.vpcname}-${local.cluster}-subnet"
   ip_cidr_range = var.cluster_subnet_cidr
-  network       = data.google_compute_network.vpc.self_link
+  network       = google_compute_network.vpc.self_link
 }
 
 resource "google_compute_router" "nat_router" {
   name    = "${local.vpcname}-${local.cluster}-router"
-  network = data.google_compute_network.vpc.self_link
+  network = google_compute_network.vpc.self_link
   bgp {
     asn = 64514
   }

--- a/variables.tf
+++ b/variables.tf
@@ -18,15 +18,18 @@ variable "access_ssh_port" {
 
 variable "num_nat_instances" {
   description = "Number of NAT instances to create, each having their own IP address"
+  type        = number
   default     = 1
 }
 
 variable "master_cidr_block" {
   description = "Private CIDR for the control plane"
+  type        = string
   default     = "172.16.32.0/28"
 }
 
 variable "cluster_subnet_cidr" {
   description = "GKE Subnet"
+  type        = string
   default     = "10.32.0.0/16"
 }


### PR DESCRIPTION
Full deploy from zero to running GKE:

```
>>> tf apply
data.google_client_config.this: Reading...
data.google_compute_zones.available: Reading...
data.google_client_config.this: Read complete after 0s [id=projects/"rainbowq"/regions/"us-west2"/zones/<null>]
data.google_compute_zones.available: Read complete after 0s [id=projects/rainbowq/regions/us-west2]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.google_container_cluster.this will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "google_container_cluster" "this" {
      + addons_config                     = (known after apply)
      + allow_net_admin                   = (known after apply)
      + authenticator_groups_config       = (known after apply)
      + binary_authorization              = (known after apply)
      + cluster_autoscaling               = (known after apply)
      + cluster_ipv4_cidr                 = (known after apply)
      + confidential_nodes                = (known after apply)
      + cost_management_config            = (known after apply)
      + database_encryption               = (known after apply)
      + datapath_provider                 = (known after apply)
      + default_max_pods_per_node         = (known after apply)
      + default_snat_status               = (known after apply)
      + deletion_protection               = (known after apply)
      + description                       = (known after apply)
      + dns_config                        = (known after apply)
      + enable_autopilot                  = (known after apply)
      + enable_intranode_visibility       = (known after apply)
      + enable_k8s_beta_apis              = (known after apply)
      + enable_kubernetes_alpha           = (known after apply)
      + enable_l4_ilb_subsetting          = (known after apply)
      + enable_legacy_abac                = (known after apply)
      + enable_shielded_nodes             = (known after apply)
      + enable_tpu                        = (known after apply)
      + endpoint                          = (known after apply)
      + fleet                             = (known after apply)
      + gateway_api_config                = (known after apply)
      + id                                = (known after apply)
      + identity_service_config           = (known after apply)
      + initial_node_count                = (known after apply)
      + ip_allocation_policy              = (known after apply)
      + label_fingerprint                 = (known after apply)
      + location                          = "us-west2"
      + logging_config                    = (known after apply)
      + logging_service                   = (known after apply)
      + maintenance_policy                = (known after apply)
      + master_auth                       = (known after apply)
      + master_authorized_networks_config = (known after apply)
      + master_version                    = (known after apply)
      + mesh_certificates                 = (known after apply)
      + min_master_version                = (known after apply)
      + monitoring_config                 = (known after apply)
      + monitoring_service                = (known after apply)
      + name                              = "qio-dev"
      + network                           = (known after apply)
      + network_policy                    = (known after apply)
      + networking_mode                   = (known after apply)
      + node_config                       = (known after apply)
      + node_locations                    = (known after apply)
      + node_pool                         = (known after apply)
      + node_pool_auto_config             = (known after apply)
      + node_pool_defaults                = (known after apply)
      + node_version                      = (known after apply)
      + notification_config               = (known after apply)
      + operation                         = (known after apply)
      + private_cluster_config            = (known after apply)
      + private_ipv6_google_access        = (known after apply)
      + release_channel                   = (known after apply)
      + remove_default_node_pool          = (known after apply)
      + resource_labels                   = (known after apply)
      + resource_usage_export_config      = (known after apply)
      + security_posture_config           = (known after apply)
      + self_link                         = (known after apply)
      + service_external_ips_config       = (known after apply)
      + services_ipv4_cidr                = (known after apply)
      + subnetwork                        = (known after apply)
      + tpu_ipv4_cidr_block               = (known after apply)
      + vertical_pod_autoscaling          = (known after apply)
      + workload_identity_config          = (known after apply)
    }

  # google_compute_address.nat_address[0] will be created
  + resource "google_compute_address" "nat_address" {
      + address            = (known after apply)
      + address_type       = "EXTERNAL"
      + creation_timestamp = (known after apply)
      + effective_labels   = (known after apply)
      + id                 = (known after apply)
      + label_fingerprint  = (known after apply)
      + name               = "nat-rainbownet-qio-dev-0"
      + network_tier       = (known after apply)
      + prefix_length      = (known after apply)
      + project            = "rainbowq"
      + purpose            = (known after apply)
      + region             = (known after apply)
      + self_link          = (known after apply)
      + subnetwork         = (known after apply)
      + terraform_labels   = (known after apply)
      + users              = (known after apply)
    }

  # google_compute_firewall.access will be created
  + resource "google_compute_firewall" "access" {
      + creation_timestamp = (known after apply)
      + destination_ranges = (known after apply)
      + direction          = (known after apply)
      + enable_logging     = (known after apply)
      + id                 = (known after apply)
      + name               = "rainbownet-default"
      + network            = "rainbownet"
      + priority           = 1000
      + project            = "rainbowq"
      + self_link          = (known after apply)
      + source_ranges      = [
          + "0.0.0.0/0",
        ]

      + allow {
          + ports    = [
              + "22",
            ]
          + protocol = "tcp"
        }
      + allow {
          + ports    = [
              + "80",
              + "443",
            ]
          + protocol = "tcp"
        }
    }

  # google_compute_network.vpc will be created
  + resource "google_compute_network" "vpc" {
      + auto_create_subnetworks                   = true
      + delete_default_routes_on_create           = false
      + gateway_ipv4                              = (known after apply)
      + id                                        = (known after apply)
      + internal_ipv6_range                       = (known after apply)
      + mtu                                       = (known after apply)
      + name                                      = "rainbownet"
      + network_firewall_policy_enforcement_order = "AFTER_CLASSIC_FIREWALL"
      + project                                   = "rainbowq"
      + routing_mode                              = (known after apply)
      + self_link                                 = (known after apply)
    }

  # google_compute_router.nat_router will be created
  + resource "google_compute_router" "nat_router" {
      + creation_timestamp = (known after apply)
      + id                 = (known after apply)
      + name               = "rainbownet-qio-dev-router"
      + network            = (known after apply)
      + project            = "rainbowq"
      + region             = (known after apply)
      + self_link          = (known after apply)

      + bgp {
          + advertise_mode     = "DEFAULT"
          + asn                = 64514
          + keepalive_interval = 20
        }
    }

  # google_compute_router_nat.nat will be created
  + resource "google_compute_router_nat" "nat" {
      + enable_dynamic_port_allocation      = (known after apply)
      + enable_endpoint_independent_mapping = (known after apply)
      + icmp_idle_timeout_sec               = 30
      + id                                  = (known after apply)
      + name                                = "rainbownet-qio-dev-nat"
      + nat_ip_allocate_option              = "MANUAL_ONLY"
      + nat_ips                             = (known after apply)
      + project                             = "rainbowq"
      + region                              = (known after apply)
      + router                              = "rainbownet-qio-dev-router"
      + source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
      + tcp_established_idle_timeout_sec    = 1200
      + tcp_time_wait_timeout_sec           = 120
      + tcp_transitory_idle_timeout_sec     = 30
      + udp_idle_timeout_sec                = 30

      + subnetwork {
          + name                     = "rainbownet-qio-dev-subnet"
          + secondary_ip_range_names = []
          + source_ip_ranges_to_nat  = [
              + "ALL_IP_RANGES",
            ]
        }
    }

  # google_compute_subnetwork.cluster_subnetwork will be created
  + resource "google_compute_subnetwork" "cluster_subnetwork" {
      + creation_timestamp         = (known after apply)
      + external_ipv6_prefix       = (known after apply)
      + fingerprint                = (known after apply)
      + gateway_address            = (known after apply)
      + id                         = (known after apply)
      + internal_ipv6_prefix       = (known after apply)
      + ip_cidr_range              = "10.32.0.0/16"
      + ipv6_cidr_range            = (known after apply)
      + name                       = "rainbownet-qio-dev-subnet"
      + network                    = (known after apply)
      + private_ip_google_access   = (known after apply)
      + private_ipv6_google_access = (known after apply)
      + project                    = "rainbowq"
      + purpose                    = (known after apply)
      + region                     = (known after apply)
      + secondary_ip_range         = (known after apply)
      + self_link                  = (known after apply)
      + stack_type                 = (known after apply)
    }

  # google_compute_subnetwork.vpc_default will be created
  + resource "google_compute_subnetwork" "vpc_default" {
      + creation_timestamp         = (known after apply)
      + external_ipv6_prefix       = (known after apply)
      + fingerprint                = (known after apply)
      + gateway_address            = (known after apply)
      + id                         = (known after apply)
      + internal_ipv6_prefix       = (known after apply)
      + ip_cidr_range              = "10.0.0.0/16"
      + ipv6_cidr_range            = (known after apply)
      + name                       = "rainbownet-subnet"
      + network                    = (known after apply)
      + private_ip_google_access   = (known after apply)
      + private_ipv6_google_access = (known after apply)
      + project                    = "rainbowq"
      + purpose                    = (known after apply)
      + region                     = (known after apply)
      + secondary_ip_range         = (known after apply)
      + self_link                  = (known after apply)
      + stack_type                 = (known after apply)
    }

  # google_container_cluster.primary will be created
  + resource "google_container_cluster" "primary" {
      + cluster_ipv4_cidr           = (known after apply)
      + datapath_provider           = (known after apply)
      + default_max_pods_per_node   = (known after apply)
      + deletion_protection         = false
      + enable_intranode_visibility = (known after apply)
      + enable_kubernetes_alpha     = false
      + enable_l4_ilb_subsetting    = false
      + enable_legacy_abac          = false
      + enable_shielded_nodes       = true
      + endpoint                    = (known after apply)
      + id                          = (known after apply)
      + initial_node_count          = 1
      + label_fingerprint           = (known after apply)
      + location                    = "us-west2"
      + logging_service             = (known after apply)
      + master_version              = (known after apply)
      + monitoring_service          = (known after apply)
      + name                        = "qio-dev"
      + network                     = (known after apply)
      + networking_mode             = (known after apply)
      + node_locations              = (known after apply)
      + node_version                = (known after apply)
      + operation                   = (known after apply)
      + private_ipv6_google_access  = (known after apply)
      + project                     = "rainbowq"
      + self_link                   = (known after apply)
      + services_ipv4_cidr          = (known after apply)
      + subnetwork                  = "rainbownet-qio-dev-subnet"
      + tpu_ipv4_cidr_block         = (known after apply)

      + master_authorized_networks_config {
          + gcp_public_cidrs_access_enabled = (known after apply)

          + cidr_blocks {
              + cidr_block   = "10.0.0.0/16"
              + display_name = "vpc_allowed"
            }
        }
    }

Plan: 8 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_compute_network.vpc: Creating...
google_compute_address.nat_address[0]: Creating...
google_compute_network.vpc: Still creating... [10s elapsed]
google_compute_address.nat_address[0]: Still creating... [10s elapsed]
google_compute_address.nat_address[0]: Creation complete after 12s [id=projects/rainbowq/regions/us-west2/addresses/nat-rainbownet-qio-dev-0]
google_compute_network.vpc: Still creating... [20s elapsed]
google_compute_network.vpc: Still creating... [30s elapsed]
google_compute_network.vpc: Still creating... [40s elapsed]
google_compute_network.vpc: Creation complete after 42s [id=projects/rainbowq/global/networks/rainbownet]
google_compute_subnetwork.vpc_default: Creating...
google_compute_router.nat_router: Creating...
google_compute_subnetwork.cluster_subnetwork: Creating...
google_compute_firewall.access: Creating...
google_compute_subnetwork.cluster_subnetwork: Still creating... [10s elapsed]
google_compute_subnetwork.vpc_default: Still creating... [10s elapsed]
google_compute_router.nat_router: Still creating... [10s elapsed]
google_compute_firewall.access: Still creating... [10s elapsed]
google_compute_firewall.access: Creation complete after 11s [id=projects/rainbowq/global/firewalls/rainbownet-default]
google_compute_router.nat_router: Still creating... [20s elapsed]
google_compute_subnetwork.cluster_subnetwork: Still creating... [20s elapsed]
google_compute_subnetwork.vpc_default: Still creating... [20s elapsed]
google_compute_router.nat_router: Creation complete after 21s [id=projects/rainbowq/regions/us-west2/routers/rainbownet-qio-dev-router]
google_compute_subnetwork.vpc_default: Creation complete after 22s [id=projects/rainbowq/regions/us-west2/subnetworks/rainbownet-subnet]
google_compute_subnetwork.cluster_subnetwork: Creation complete after 22s [id=projects/rainbowq/regions/us-west2/subnetworks/rainbownet-qio-dev-subnet]
google_container_cluster.primary: Creating...
google_container_cluster.primary: Still creating... [10s elapsed]
google_container_cluster.primary: Still creating... [20s elapsed]
google_container_cluster.primary: Still creating... [30s elapsed]
google_container_cluster.primary: Still creating... [40s elapsed]
google_container_cluster.primary: Still creating... [50s elapsed]
google_container_cluster.primary: Still creating... [1m0s elapsed]
google_container_cluster.primary: Still creating... [1m10s elapsed]
google_container_cluster.primary: Still creating... [1m20s elapsed]
google_container_cluster.primary: Still creating... [1m30s elapsed]
google_container_cluster.primary: Still creating... [1m40s elapsed]
google_container_cluster.primary: Still creating... [1m50s elapsed]
google_container_cluster.primary: Still creating... [2m0s elapsed]
google_container_cluster.primary: Still creating... [2m10s elapsed]
google_container_cluster.primary: Still creating... [2m20s elapsed]
google_container_cluster.primary: Still creating... [2m30s elapsed]
google_container_cluster.primary: Still creating... [2m40s elapsed]
google_container_cluster.primary: Still creating... [2m50s elapsed]
google_container_cluster.primary: Still creating... [3m0s elapsed]
google_container_cluster.primary: Still creating... [3m10s elapsed]
google_container_cluster.primary: Still creating... [3m20s elapsed]
google_container_cluster.primary: Still creating... [3m30s elapsed]
google_container_cluster.primary: Still creating... [3m40s elapsed]
google_container_cluster.primary: Still creating... [3m50s elapsed]
google_container_cluster.primary: Still creating... [4m0s elapsed]
google_container_cluster.primary: Still creating... [4m10s elapsed]
google_container_cluster.primary: Still creating... [4m20s elapsed]
google_container_cluster.primary: Still creating... [4m30s elapsed]
google_container_cluster.primary: Still creating... [4m40s elapsed]
google_container_cluster.primary: Still creating... [4m50s elapsed]
google_container_cluster.primary: Still creating... [5m0s elapsed]
google_container_cluster.primary: Still creating... [5m10s elapsed]
google_container_cluster.primary: Still creating... [5m20s elapsed]
google_container_cluster.primary: Still creating... [5m30s elapsed]
google_container_cluster.primary: Still creating... [5m40s elapsed]
google_container_cluster.primary: Creation complete after 5m41s [id=projects/rainbowq/locations/us-west2/clusters/qio-dev]
data.google_container_cluster.this: Reading...
google_compute_router_nat.nat: Creating...
data.google_container_cluster.this: Read complete after 1s [id=projects/rainbowq/locations/us-west2/clusters/qio-dev]
google_compute_router_nat.nat: Still creating... [10s elapsed]
google_compute_router_nat.nat: Still creating... [20s elapsed]
google_compute_router_nat.nat: Creation complete after 23s [id=rainbowq/us-west2/rainbownet-qio-dev-router/rainbownet-qio-dev-nat]

Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
<<< 16:36.46 Tue Dec/12/23|~/dev/github/maroda/craq.dev
<<< matt@earthsea|4149 git:main vim:command
>>>
```