### PR TITLE
eki bastion now deploys alongside cluster

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -1,0 +1,39 @@
+resource "google_compute_address" "eki" {
+  name         = "${var.hostname}-${local.vpcname}"
+  address_type = "EXTERNAL"
+  depends_on   = [google_compute_network.vpc]
+}
+
+resource "google_compute_instance" "eki" {
+  name         = "eki"
+  machine_type = "e2-medium"
+  zone         = "us-west2-b"
+  depends_on   = [google_compute_network.vpc]
+
+  tags = ["access", "eki"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    //network    = google_compute_network.vpc.self_link
+    subnetwork = google_compute_subnetwork.vpc_default.self_link
+    access_config {
+      nat_ip = google_compute_address.eki.address
+    }
+  }
+
+  metadata = {
+    env = "dev"
+  }
+
+  metadata_startup_script = "apt-get install kubectl google-cloud-sdk-gke-gcloud-auth-plugin"
+
+  service_account {
+    email  = local.srvacct
+    scopes = ["cloud-platform"]
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -12,11 +12,3 @@ data "google_container_cluster" "this" {
 }
 
 data "google_compute_zones" "available" {}
-
-//data "google_compute_network" "vpc" {
-//  name = local.vpcname
-//}
-
-//data "google_compute_subnetwork" "vpc_default" {
-//  name = "${local.vpcname}-subnet"
-//}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,3 @@
-//variable "environment" { description = "Environment (free form, used for naming)" }
-//variable "kubernetes_version" { description = "GKE version" }
 //variable "endpoint_toggle" {
 //  description = "Toggle the availability of a public endpoint for the GKE API: 'false' means both public and private, 'true' means only private."
 //  default     = "false"
@@ -32,4 +30,10 @@ variable "cluster_subnet_cidr" {
   description = "GKE Subnet"
   type        = string
   default     = "10.32.0.0/16"
+}
+
+variable "hostname" {
+  description = "The unique hostname without the domain (i.e. this is not a FQDN)."
+  type        = string
+  default     = "eki"
 }


### PR DESCRIPTION
Successful deploy of GKE with Eki bastion, applied plan:

```
>>> tf apply
data.google_compute_zones.available: Reading...
data.google_client_config.this: Reading...
data.google_client_config.this: Read complete after 0s [id=projects/"rainbowq"/regions/"us-west2"/zones/<null>]
data.google_compute_zones.available: Read complete after 1s [id=projects/rainbowq/regions/us-west2]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.google_container_cluster.this will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "google_container_cluster" "this" {
      + addons_config                     = (known after apply)
      + allow_net_admin                   = (known after apply)
      + authenticator_groups_config       = (known after apply)
      + binary_authorization              = (known after apply)
      + cluster_autoscaling               = (known after apply)
      + cluster_ipv4_cidr                 = (known after apply)
      + confidential_nodes                = (known after apply)
      + cost_management_config            = (known after apply)
      + database_encryption               = (known after apply)
      + datapath_provider                 = (known after apply)
      + default_max_pods_per_node         = (known after apply)
      + default_snat_status               = (known after apply)
      + deletion_protection               = (known after apply)
      + description                       = (known after apply)
      + dns_config                        = (known after apply)
      + enable_autopilot                  = (known after apply)
      + enable_intranode_visibility       = (known after apply)
      + enable_k8s_beta_apis              = (known after apply)
      + enable_kubernetes_alpha           = (known after apply)
      + enable_l4_ilb_subsetting          = (known after apply)
      + enable_legacy_abac                = (known after apply)
      + enable_shielded_nodes             = (known after apply)
      + enable_tpu                        = (known after apply)
      + endpoint                          = (known after apply)
      + fleet                             = (known after apply)
      + gateway_api_config                = (known after apply)
      + id                                = (known after apply)
      + identity_service_config           = (known after apply)
      + initial_node_count                = (known after apply)
      + ip_allocation_policy              = (known after apply)
      + label_fingerprint                 = (known after apply)
      + location                          = "us-west2"
      + logging_config                    = (known after apply)
      + logging_service                   = (known after apply)
      + maintenance_policy                = (known after apply)
      + master_auth                       = (known after apply)
      + master_authorized_networks_config = (known after apply)
      + master_version                    = (known after apply)
      + mesh_certificates                 = (known after apply)
      + min_master_version                = (known after apply)
      + monitoring_config                 = (known after apply)
      + monitoring_service                = (known after apply)
      + name                              = "qio-dev"
      + network                           = (known after apply)
      + network_policy                    = (known after apply)
      + networking_mode                   = (known after apply)
      + node_config                       = (known after apply)
      + node_locations                    = (known after apply)
      + node_pool                         = (known after apply)
      + node_pool_auto_config             = (known after apply)
      + node_pool_defaults                = (known after apply)
      + node_version                      = (known after apply)
      + notification_config               = (known after apply)
      + operation                         = (known after apply)
      + private_cluster_config            = (known after apply)
      + private_ipv6_google_access        = (known after apply)
      + release_channel                   = (known after apply)
      + remove_default_node_pool          = (known after apply)
      + resource_labels                   = (known after apply)
      + resource_usage_export_config      = (known after apply)
      + security_posture_config           = (known after apply)
      + self_link                         = (known after apply)
      + service_external_ips_config       = (known after apply)
      + services_ipv4_cidr                = (known after apply)
      + subnetwork                        = (known after apply)
      + tpu_ipv4_cidr_block               = (known after apply)
      + vertical_pod_autoscaling          = (known after apply)
      + workload_identity_config          = (known after apply)
    }

  # google_compute_address.eki will be created
  + resource "google_compute_address" "eki" {
      + address            = (known after apply)
      + address_type       = "EXTERNAL"
      + creation_timestamp = (known after apply)
      + effective_labels   = (known after apply)
      + id                 = (known after apply)
      + label_fingerprint  = (known after apply)
      + name               = "eki-rainbownet"
      + network_tier       = (known after apply)
      + prefix_length      = (known after apply)
      + project            = "rainbowq"
      + purpose            = (known after apply)
      + region             = (known after apply)
      + self_link          = (known after apply)
      + subnetwork         = (known after apply)
      + terraform_labels   = (known after apply)
      + users              = (known after apply)
    }

  # google_compute_address.nat_address[0] will be created
  + resource "google_compute_address" "nat_address" {
      + address            = (known after apply)
      + address_type       = "EXTERNAL"
      + creation_timestamp = (known after apply)
      + effective_labels   = (known after apply)
      + id                 = (known after apply)
      + label_fingerprint  = (known after apply)
      + name               = "nat-rainbownet-qio-dev-0"
      + network_tier       = (known after apply)
      + prefix_length      = (known after apply)
      + project            = "rainbowq"
      + purpose            = (known after apply)
      + region             = (known after apply)
      + self_link          = (known after apply)
      + subnetwork         = (known after apply)
      + terraform_labels   = (known after apply)
      + users              = (known after apply)
    }

  # google_compute_firewall.access will be created
  + resource "google_compute_firewall" "access" {
      + creation_timestamp = (known after apply)
      + destination_ranges = (known after apply)
      + direction          = (known after apply)
      + enable_logging     = (known after apply)
      + id                 = (known after apply)
      + name               = "rainbownet-default"
      + network            = "rainbownet"
      + priority           = 1000
      + project            = "rainbowq"
      + self_link          = (known after apply)
      + source_ranges      = [
          + "0.0.0.0/0",
        ]

      + allow {
          + ports    = [
              + "22",
            ]
          + protocol = "tcp"
        }
      + allow {
          + ports    = [
              + "80",
              + "443",
            ]
          + protocol = "tcp"
        }
    }

  # google_compute_instance.eki will be created
  + resource "google_compute_instance" "eki" {
      + can_ip_forward          = false
      + cpu_platform            = (known after apply)
      + current_status          = (known after apply)
      + deletion_protection     = false
      + effective_labels        = (known after apply)
      + guest_accelerator       = (known after apply)
      + id                      = (known after apply)
      + instance_id             = (known after apply)
      + label_fingerprint       = (known after apply)
      + machine_type            = "e2-medium"
      + metadata                = {
          + "env" = "dev"
        }
      + metadata_fingerprint    = (known after apply)
      + metadata_startup_script = "apt-get install kubectl google-cloud-sdk-gke-gcloud-auth-plugin"
      + min_cpu_platform        = (known after apply)
      + name                    = "eki"
      + project                 = "rainbowq"
      + self_link               = (known after apply)
      + tags                    = [
          + "access",
          + "eki",
        ]
      + tags_fingerprint        = (known after apply)
      + terraform_labels        = (known after apply)
      + zone                    = "us-west2-b"

      + boot_disk {
          + auto_delete                = true
          + device_name                = (known after apply)
          + disk_encryption_key_sha256 = (known after apply)
          + kms_key_self_link          = (known after apply)
          + mode                       = "READ_WRITE"
          + source                     = (known after apply)

          + initialize_params {
              + image  = "debian-cloud/debian-11"
              + labels = (known after apply)
              + size   = (known after apply)
              + type   = (known after apply)
            }
        }

      + network_interface {
          + internal_ipv6_prefix_length = (known after apply)
          + ipv6_access_type            = (known after apply)
          + ipv6_address                = (known after apply)
          + name                        = (known after apply)
          + network                     = (known after apply)
          + network_ip                  = (known after apply)
          + stack_type                  = (known after apply)
          + subnetwork                  = (known after apply)
          + subnetwork_project          = (known after apply)

          + access_config {
              + nat_ip       = (known after apply)
              + network_tier = (known after apply)
            }
        }

      + service_account {
          + email  = "rainbowqio@rainbowq.iam.gserviceaccount.com"
          + scopes = [
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
        }
    }

  # google_compute_network.vpc will be created
  + resource "google_compute_network" "vpc" {
      + auto_create_subnetworks                   = true
      + delete_default_routes_on_create           = false
      + gateway_ipv4                              = (known after apply)
      + id                                        = (known after apply)
      + internal_ipv6_range                       = (known after apply)
      + mtu                                       = (known after apply)
      + name                                      = "rainbownet"
      + network_firewall_policy_enforcement_order = "AFTER_CLASSIC_FIREWALL"
      + project                                   = "rainbowq"
      + routing_mode                              = (known after apply)
      + self_link                                 = (known after apply)
    }

  # google_compute_router.nat_router will be created
  + resource "google_compute_router" "nat_router" {
      + creation_timestamp = (known after apply)
      + id                 = (known after apply)
      + name               = "rainbownet-qio-dev-router"
      + network            = (known after apply)
      + project            = "rainbowq"
      + region             = (known after apply)
      + self_link          = (known after apply)

      + bgp {
          + advertise_mode     = "DEFAULT"
          + asn                = 64514
          + keepalive_interval = 20
        }
    }

  # google_compute_router_nat.nat will be created
  + resource "google_compute_router_nat" "nat" {
      + enable_dynamic_port_allocation      = (known after apply)
      + enable_endpoint_independent_mapping = (known after apply)
      + icmp_idle_timeout_sec               = 30
      + id                                  = (known after apply)
      + name                                = "rainbownet-qio-dev-nat"
      + nat_ip_allocate_option              = "MANUAL_ONLY"
      + nat_ips                             = (known after apply)
      + project                             = "rainbowq"
      + region                              = (known after apply)
      + router                              = "rainbownet-qio-dev-router"
      + source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
      + tcp_established_idle_timeout_sec    = 1200
      + tcp_time_wait_timeout_sec           = 120
      + tcp_transitory_idle_timeout_sec     = 30
      + udp_idle_timeout_sec                = 30

      + subnetwork {
          + name                     = "rainbownet-qio-dev-subnet"
          + secondary_ip_range_names = []
          + source_ip_ranges_to_nat  = [
              + "ALL_IP_RANGES",
            ]
        }
    }

  # google_compute_subnetwork.cluster_subnetwork will be created
  + resource "google_compute_subnetwork" "cluster_subnetwork" {
      + creation_timestamp         = (known after apply)
      + external_ipv6_prefix       = (known after apply)
      + fingerprint                = (known after apply)
      + gateway_address            = (known after apply)
      + id                         = (known after apply)
      + internal_ipv6_prefix       = (known after apply)
      + ip_cidr_range              = "10.32.0.0/16"
      + ipv6_cidr_range            = (known after apply)
      + name                       = "rainbownet-qio-dev-subnet"
      + network                    = (known after apply)
      + private_ip_google_access   = (known after apply)
      + private_ipv6_google_access = (known after apply)
      + project                    = "rainbowq"
      + purpose                    = (known after apply)
      + region                     = (known after apply)
      + secondary_ip_range         = (known after apply)
      + self_link                  = (known after apply)
      + stack_type                 = (known after apply)
    }

  # google_compute_subnetwork.vpc_default will be created
  + resource "google_compute_subnetwork" "vpc_default" {
      + creation_timestamp         = (known after apply)
      + external_ipv6_prefix       = (known after apply)
      + fingerprint                = (known after apply)
      + gateway_address            = (known after apply)
      + id                         = (known after apply)
      + internal_ipv6_prefix       = (known after apply)
      + ip_cidr_range              = "10.0.0.0/16"
      + ipv6_cidr_range            = (known after apply)
      + name                       = "rainbownet-subnet"
      + network                    = (known after apply)
      + private_ip_google_access   = (known after apply)
      + private_ipv6_google_access = (known after apply)
      + project                    = "rainbowq"
      + purpose                    = (known after apply)
      + region                     = (known after apply)
      + secondary_ip_range         = (known after apply)
      + self_link                  = (known after apply)
      + stack_type                 = (known after apply)
    }

  # google_container_cluster.primary will be created
  + resource "google_container_cluster" "primary" {
      + cluster_ipv4_cidr           = (known after apply)
      + datapath_provider           = (known after apply)
      + default_max_pods_per_node   = (known after apply)
      + deletion_protection         = false
      + enable_intranode_visibility = (known after apply)
      + enable_kubernetes_alpha     = false
      + enable_l4_ilb_subsetting    = false
      + enable_legacy_abac          = false
      + enable_shielded_nodes       = true
      + endpoint                    = (known after apply)
      + id                          = (known after apply)
      + initial_node_count          = 1
      + label_fingerprint           = (known after apply)
      + location                    = "us-west2"
      + logging_service             = (known after apply)
      + master_version              = (known after apply)
      + monitoring_service          = (known after apply)
      + name                        = "qio-dev"
      + network                     = (known after apply)
      + networking_mode             = (known after apply)
      + node_locations              = (known after apply)
      + node_version                = (known after apply)
      + operation                   = (known after apply)
      + private_ipv6_google_access  = (known after apply)
      + project                     = "rainbowq"
      + self_link                   = (known after apply)
      + services_ipv4_cidr          = (known after apply)
      + subnetwork                  = "rainbownet-qio-dev-subnet"
      + tpu_ipv4_cidr_block         = (known after apply)

      + master_authorized_networks_config {
          + gcp_public_cidrs_access_enabled = (known after apply)

          + cidr_blocks {
              + cidr_block   = "10.0.0.0/16"
              + display_name = "vpc_allowed"
            }
        }
    }

Plan: 10 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes
```