### PR TITLE
master-allowed networks expanded

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -9,7 +9,6 @@ resource "google_container_cluster" "primary" {
   subnetwork            = google_compute_subnetwork.cluster_subnetwork.name
   enable_shielded_nodes = true
   initial_node_count    = 1
-  // min_master_version    = var.kubernetes_version
 
   # Needed for destroying the cluster for iterative dev
   deletion_protection = false
@@ -19,6 +18,10 @@ resource "google_container_cluster" "primary" {
     cidr_blocks {
       cidr_block   = google_compute_subnetwork.vpc_default.ip_cidr_range
       display_name = "vpc_allowed"
+    }
+    cidr_blocks {
+      cidr_block   = "104.12.83.124/32"
+      display_name = "craquemattic"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_subnet" {
+  value = google_compute_subnetwork.vpc_default.self_link
+}
+
+output "nat_address" {
+  value = google_compute_address.nat_address.*.address
+}
+
+output "endpoint" {
+  value = google_container_cluster.primary.endpoint
+}
+
+output "gke_master_version" {
+  value = google_container_cluster.primary.master_version
+}
+
+output "gke_public_endpoint" {
+  value = google_container_cluster.primary.private_cluster_config.*.public_endpoint
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-//variable "endpoint_toggle" {
-//  description = "Toggle the availability of a public endpoint for the GKE API: 'false' means both public and private, 'true' means only private."
-//  default     = "false"
-//}
 variable "primary_cidr" {
   description = "Primary CIDR for the VPC"
   type        = string


### PR DESCRIPTION
Adding my home egress to the API ACL:
```
  # google_container_cluster.primary will be updated in-place
  ~ resource "google_container_cluster" "primary" {
        id                          = "projects/rainbowq/locations/us-west2/clusters/qio-dev"
        name                        = "qio-dev"
        # (26 unchanged attributes hidden)

      ~ master_authorized_networks_config {
            # (1 unchanged attribute hidden)

          + cidr_blocks {
              + cidr_block   = "104.12.83.124/32"
              + display_name = "craquemattic"
            }

            # (1 unchanged block hidden)
        }

        # (18 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```