### PR TITLE
DNS delegated and records working for managed zone

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,23 @@
+resource "google_dns_record_set" "host" {
+  name         = "${var.hostname}.ghost.${local.domain}."
+  managed_zone = local.dnszone
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_address.eki.address]
+}
+
+resource "google_dns_record_set" "primary" {
+  name         = "ghost.${local.domain}."
+  managed_zone = local.dnszone
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_container_cluster.primary.endpoint]
+}
+
+resource "google_dns_record_set" "www" {
+  name         = "www.${local.domain}."
+  managed_zone = local.dnszone
+  type         = "CNAME"
+  ttl          = 300
+  rrdatas      = [google_dns_record_set.primary.name]
+}

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,8 @@ locals {
   region  = "us-west2"
   vpcname = "rainbownet"
   cluster = "qio-dev"
+  dnszone = "craqdev"
+  domain  = "craq.dev"
   srvacct = "rainbowqio@rainbowq.iam.gserviceaccount.com"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,10 @@ output "gke_master_version" {
   value = google_container_cluster.primary.master_version
 }
 
-output "gke_public_endpoint" {
-  value = google_container_cluster.primary.private_cluster_config.*.public_endpoint
+output "dns_primary" {
+  value = google_dns_record_set.primary.name
+}
+
+output "dns_host" {
+  value = google_dns_record_set.host.name
 }


### PR DESCRIPTION
DNS for the eki host and the cluster primary public IP are now set.
```
Outputs:

dns_host = "eki.ghost.craq.dev."
dns_primary = "ghost.craq.dev."
endpoint = "34.94.82.250"
gke_master_version = "1.27.3-gke.100"
nat_address = [
  "34.94.226.67",
]
vpc_subnet = "https://www.googleapis.com/compute/v1/projects/rainbowq/regions/us-west2/subnetworks/rainbownet-subnet"
```