### PR TITLE
ghost chart deploys and runs

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -4,6 +4,12 @@ resource "google_compute_address" "eki" {
   depends_on   = [google_compute_network.vpc]
 }
 
+resource "google_compute_address" "web" {
+  name         = "${local.vpcname}-web"
+  address_type = "EXTERNAL"
+  depends_on   = [google_compute_network.vpc]
+}
+
 resource "google_compute_instance" "eki" {
   name         = "eki"
   machine_type = "e2-medium"

--- a/data.tf
+++ b/data.tf
@@ -11,4 +11,4 @@ data "google_container_cluster" "this" {
   depends_on = [google_container_cluster.primary]
 }
 
-data "google_compute_zones" "available" {}
+// data "google_compute_zones" "available" {}

--- a/dns.tf
+++ b/dns.tf
@@ -11,13 +11,5 @@ resource "google_dns_record_set" "primary" {
   managed_zone = local.dnszone
   type         = "A"
   ttl          = 300
-  rrdatas      = [google_container_cluster.primary.endpoint]
-}
-
-resource "google_dns_record_set" "www" {
-  name         = "www.${local.domain}."
-  managed_zone = local.dnszone
-  type         = "CNAME"
-  ttl          = 300
-  rrdatas      = [google_dns_record_set.primary.name]
+  rrdatas      = [google_compute_address.web.address]
 }

--- a/helm.tf
+++ b/helm.tf
@@ -1,0 +1,55 @@
+/*
+ * Helm config with Chart
+ */
+resource "helm_release" "ghost" {
+  name       = "ghost"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "ghost"
+  depends_on = [google_container_cluster.primary]
+
+  //values = [
+  //    file("${path.module}/ghost-values.yaml")
+  // ]
+
+  set {
+    name  = "service.loadBalancerIP"
+    value = google_compute_address.web.address
+  }
+  //set {
+  //  name  = "bitnami_debug"
+  // value = "true"
+  //}
+  set {
+    name  = "ghostUsername"
+    value = var.gUsername
+  }
+  set {
+    name  = "ghostPassword"
+    value = var.gPassword
+  }
+  set {
+    name  = "ghostEmail"
+    value = var.gEmail
+  }
+  set {
+    name  = "ghostBlogTitle"
+    value = var.gBlogTitle
+  }
+  set {
+    name  = "ghostHost"
+    value = var.gHost
+  }
+  //set {
+  //    name  = "ghostEnableHttps"
+  //   value = "true"
+  //}
+
+  set {
+    name  = "mysql.auth.rootPassword"
+    value = var.mRPassword
+  }
+  set {
+    name  = "mysql.auth.password"
+    value = var.mPassword
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ provider "kubernetes" {
   host  = "https://${data.google_container_cluster.this.endpoint}"
   token = data.google_client_config.this.access_token
   cluster_ca_certificate = base64decode(
-    data.google_container_cluster.this.master_auth.0.cluster_ca_certificate,
+    data.google_container_cluster.this.master_auth[0].cluster_ca_certificate,
   )
 }
 
@@ -49,7 +49,7 @@ provider "helm" {
     host  = "https://${data.google_container_cluster.this.endpoint}"
     token = data.google_client_config.this.access_token
     cluster_ca_certificate = base64decode(
-      data.google_container_cluster.this.master_auth.0.cluster_ca_certificate,
+      data.google_container_cluster.this.master_auth[0].cluster_ca_certificate,
     )
   }
 }

--- a/net.tf
+++ b/net.tf
@@ -24,7 +24,7 @@ resource "google_compute_router_nat" "nat" {
   name                               = "${local.vpcname}-${local.cluster}-nat"
   router                             = google_compute_router.nat_router.name
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = google_compute_address.nat_address.*.self_link
+  nat_ips                            = google_compute_address.nat_address[*].self_link
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   subnetwork {
     name                    = google_compute_subnetwork.cluster_subnetwork.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "vpc_subnet" {
 }
 
 output "nat_address" {
-  value = google_compute_address.nat_address.*.address
+  value = google_compute_address.nat_address[*].address
 }
 
 output "endpoint" {
@@ -20,4 +20,23 @@ output "dns_primary" {
 
 output "dns_host" {
   value = google_dns_record_set.host.name
+}
+
+output "loadBalancerIP" {
+  value = google_compute_address.web.address
+}
+
+output "client_certificate" {
+  value     = google_container_cluster.primary.master_auth[0].client_certificate
+  sensitive = true
+}
+
+output "client_key" {
+  value     = google_container_cluster.primary.master_auth[0].client_key
+  sensitive = true
+}
+
+output "cluster_ca_certificate" {
+  value     = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+  sensitive = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
+/*
+   Infrastructure
+   */
+
 variable "primary_cidr" {
   description = "Primary CIDR for the VPC"
   type        = string
@@ -16,12 +20,6 @@ variable "num_nat_instances" {
   default     = 1
 }
 
-variable "master_cidr_block" {
-  description = "Private CIDR for the control plane"
-  type        = string
-  default     = "172.16.32.0/28"
-}
-
 variable "cluster_subnet_cidr" {
   description = "GKE Subnet"
   type        = string
@@ -32,4 +30,43 @@ variable "hostname" {
   description = "The unique hostname without the domain (i.e. this is not a FQDN)."
   type        = string
   default     = "eki"
+}
+
+/*
+   Ghost
+   */
+
+variable "gUsername" {
+  type    = string
+  default = "craque"
+}
+
+variable "gPassword" {
+  type    = string
+  default = "cage433four6"
+}
+
+variable "gEmail" {
+  type    = string
+  default = "craque@craque.net"
+}
+
+variable "gBlogTitle" {
+  type    = string
+  default = "CRAQDEV"
+}
+
+variable "gHost" {
+  type    = string
+  default = "ghost.craq.dev"
+}
+
+variable "mRPassword" {
+  type    = string
+  default = "four6cage433"
+}
+
+variable "mPassword" {
+  type    = string
+  default = "four433cage6"
 }


### PR DESCRIPTION
Clearing everything out and starting from a barebones config got us the right combination of values and it is returning the blog at ghost.craq.dev:

```
>>> curl ghost.craq.dev
<!DOCTYPE html>
<html lang="en">
<head>

    <title>CRAQDEV</title>
```

```
Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # helm_release.ghost will be created
  + resource "helm_release" "ghost" {
      + atomic                     = false
      + chart                      = "ghost"
      + cleanup_on_fail            = false
      + create_namespace           = false
      + dependency_update          = false
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + manifest                   = (known after apply)
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "ghost"
      + namespace                  = "default"
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://charts.bitnami.com/bitnami"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 300
      + verify                     = false
      + version                    = "19.6.14"
      + wait                       = true
      + wait_for_jobs              = false

      + set {
          + name  = "ghostBlogTitle"
          + value = "CRAQDEV"
        }
      + set {
          + name  = "ghostEmail"
          + value = "craque@craque.net"
        }
      + set {
          + name  = "ghostHost"
          + value = "ghost.craq.dev"
        }
      + set {
          + name  = "ghostPassword"
          + value = "cage433four6"
        }
      + set {
          + name  = "ghostUsername"
          + value = "craque"
        }
      + set {
          + name  = "mysql.auth.password"
          + value = "four433cage6"
        }
      + set {
          + name  = "mysql.auth.rootPassword"
          + value = "four6cage433"
        }
      + set {
          + name  = "service.loadBalancerIP"
          + value = "34.102.123.179"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

helm_release.ghost: Creating...
helm_release.ghost: Still creating... [10s elapsed]
helm_release.ghost: Still creating... [20s elapsed]
helm_release.ghost: Still creating... [30s elapsed]
helm_release.ghost: Still creating... [40s elapsed]
helm_release.ghost: Still creating... [50s elapsed]
helm_release.ghost: Still creating... [1m0s elapsed]
helm_release.ghost: Still creating... [1m10s elapsed]
helm_release.ghost: Still creating... [1m20s elapsed]
helm_release.ghost: Still creating... [1m30s elapsed]
helm_release.ghost: Still creating... [1m40s elapsed]
helm_release.ghost: Still creating... [1m50s elapsed]
helm_release.ghost: Still creating... [2m0s elapsed]
helm_release.ghost: Still creating... [2m10s elapsed]
helm_release.ghost: Creation complete after 2m17s [id=ghost]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

client_certificate = <sensitive>
client_key = <sensitive>
cluster_ca_certificate = <sensitive>
dns_host = "eki.ghost.craq.dev."
dns_primary = "ghost.craq.dev."
endpoint = "35.235.114.84"
gke_master_version = "1.27.3-gke.100"
loadBalancerIP = "34.102.123.179"
nat_address = [
  "34.102.42.50",
]
vpc_subnet = "https://www.googleapis.com/compute/v1/projects/rainbowq/regions/us-west2/subnetworks/rainbownet-subnet"
```